### PR TITLE
[REFACTOR] FeedSubMenu와 DeleteConfirmModal 역할에 따라 컴포넌트 분리

### DIFF
--- a/src/components/feed/sub/FeedSubMenu.tsx
+++ b/src/components/feed/sub/FeedSubMenu.tsx
@@ -3,7 +3,6 @@
 import { EllipsisHorizontalIcon } from "@heroicons/react/24/solid";
 import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useDeleteFeed } from "@/lib/feed/hooks";
 import { DeleteConfirmModal } from "@/components/modal/check";
 
 interface FeedSubMenuProps {
@@ -21,7 +20,6 @@ export default function FeedSubMenu({
   const [isModalVisible, setIsModalVisible] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
-  const { mutateAsync: deleteFeedMutate } = useDeleteFeed();
 
   const toggleMenu = () => {
     setIsVisible(!isVisible);
@@ -36,19 +34,9 @@ export default function FeedSubMenu({
     setIsModalVisible(false);
   };
 
-  const handleDelete = async () => {
-    try {
-      await deleteFeedMutate({ feedId, imagePath });
-      console.log("삭제되었습니다.");
-      setIsModalVisible(false);
-    } catch (error) {
-      console.error("삭제 중 오류 발생:", error);
-    }
-  };
-
   const handleEdit = () => {
     router.push(`/feed/edit/${feedId}`);
-    setIsModalVisible(false);
+    setIsVisible(false);
   };
 
   useEffect(() => {
@@ -93,7 +81,11 @@ export default function FeedSubMenu({
         </div>
       )}
       {isModalVisible && (
-        <DeleteConfirmModal onClose={closeModal} onDelete={handleDelete} />
+        <DeleteConfirmModal
+          feedId={feedId}
+          imagePath={imagePath}
+          onClose={closeModal}
+        />
       )}
     </div>
   );

--- a/src/components/modal/check/DeleteConfirmModal.tsx
+++ b/src/components/modal/check/DeleteConfirmModal.tsx
@@ -1,17 +1,31 @@
 "use client";
 
+import { useDeleteFeed } from "@/lib/feed/hooks";
 import { useEffect, useRef } from "react";
 
 interface DeleteConfirmModalProps {
+  feedId: number;
+  imagePath: string;
   onClose: () => void;
-  onDelete: () => void;
 }
 
 export default function DeleteConfirmModal({
+  feedId,
+  imagePath,
   onClose,
-  onDelete,
 }: DeleteConfirmModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const { mutateAsync: deleteFeedMutate } = useDeleteFeed();
+
+  const handleDelete = async () => {
+    try {
+      await deleteFeedMutate({ feedId, imagePath });
+      console.log("삭제되었습니다.");
+      onClose();
+    } catch (error) {
+      console.error("삭제 중 오류 발생:", error);
+    }
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -43,7 +57,7 @@ export default function DeleteConfirmModal({
           삭제됩니다.
         </p>
         <button
-          onClick={onDelete}
+          onClick={handleDelete}
           className="bg-red-500 text-white py-2 px-4 rounded-full w-full mb-2 hover:bg-red-600"
         >
           삭제


### PR DESCRIPTION
- FeedSubMenu는 메뉴 토글과 삭제/수정 옵션을 보여주는 역할만 수행
- 삭제 관련 로직은 DeleteConfirmModal에서 독립적으로 처리하도록 리팩토링